### PR TITLE
feat: Adopt to Arm64 architecture

### DIFF
--- a/packages/cdk/lib/__snapshots__/example-typescript-lambda.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/example-typescript-lambda.test.ts.snap
@@ -23,6 +23,9 @@ exports[`The ExampleTypescriptLambda stack matches the snapshot 1`] = `
         "ExampleTypescriptLambdaServiceRoleFE8EC8A1",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",

--- a/packages/cdk/lib/example-typescript-lambda.ts
+++ b/packages/cdk/lib/example-typescript-lambda.ts
@@ -2,7 +2,7 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 
 export class ExampleTypescriptLambda extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -39,6 +39,15 @@ export class ExampleTypescriptLambda extends GuStack {
 			 * Should align with `.nvmrc` at the root of the repository.
 			 */
 			runtime: Runtime.NODEJS_20_X,
+
+			/**
+			 * The architecture of the lambda function.
+			 *
+			 * Arm64 is preferred as it's more performant, and cheaper than x86_64.
+			 *
+			 * @see https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/
+			 */
+			architecture: Architecture.ARM_64,
 		});
 	}
 }


### PR DESCRIPTION
## What does this change?
Move to Arm64 based lambda as it is more performant, and cheaper.