### PR TITLE
docs: Add disclaimer about auto-approve workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ For example, dependency versions, or Node version.
 You'll want to edit some parts of the infrastructure in [packages/cdk](packages/cdk) 
 to ensure the app is deployed to the desired AWS account.
 
+You'll also want to update or remove the [Dependabot auto-approve workflow](.github/workflows/dependabot-auto-approve.yml), which keeps this repository up to date with dependencies but may not be suitable for a production lambda!
+
 [^1]: If cloning, you'll also want to [update the remote url](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories#changing-a-remote-repositorys-url) to match your repository


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a disclaimer about the Dependabot auto-approve workflow and suggestion to remove if you clone this for usage

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
